### PR TITLE
Remove unused parameters causing compilation errors

### DIFF
--- a/ext/bitset/bitset.c
+++ b/ext/bitset/bitset.c
@@ -75,7 +75,7 @@ static VALUE rb_bitset_initialize(VALUE self, VALUE ary) {
     return self;
 }
 
-static VALUE rb_bitset_size(VALUE self, VALUE len) {
+static VALUE rb_bitset_size(VALUE self) {
     Bitset * bs = get_bitset(self);
     return INT2NUM(bs->len);
 }
@@ -521,7 +521,7 @@ static VALUE rb_bitset_values_at(VALUE self, VALUE index_array) {
 }
 
 /** This could run a bit faster if you worked at it. */
-static VALUE rb_bitset_reverse(VALUE self, VALUE index_array) {
+static VALUE rb_bitset_reverse(VALUE self) {
     int i;
     Bitset * bs = get_bitset(self);
     int len = bs->len;


### PR DESCRIPTION
As noted in #7, installations currently error because the parameter counts in `rb_bitset_size` and `rb_bitset_reverse` don't match the parameter counts mentioned later on in `rb_define_method`:

```c
    rb_define_method(cBitset, "size", rb_bitset_size, 0);
    rb_define_method(cBitset, "reverse", rb_bitset_reverse, 0);
```

Since these parameters appear to be unused, this PR removes them from the function definitions.  Verified that this resolves the installation problem on MacOS ruby 3.x.